### PR TITLE
Fixed inplace editing bug and wrong script name

### DIFF
--- a/gcodeutils/filter/arc_optimizer.py
+++ b/gcodeutils/filter/arc_optimizer.py
@@ -175,7 +175,10 @@ class GCodeArcOptimizerFilter(GCodeFilter):
                 extrusions['total']['path'] += path
                 extrusions['filament'][num] = extrusion
                 extrusions['path'][num] = path
-                extrusions['ratio'][num] = extrusions['filament'][num] / path
+                if num == len(self.queue) - 1 and path > 0:
+                    extrusions['ratio'][num] = extrusions['filament'][num] / path
+                else:
+                    extrusions['ratio'][num] = -1
             prev = line
         extrusions['avg']['filament'] = extrusions['total']['filament'] / len(self.queue)
         extrusions['avg']['path'] = extrusions['total']['path'] / len(self.queue)

--- a/gcodeutils/filter/arc_optimizer.py
+++ b/gcodeutils/filter/arc_optimizer.py
@@ -175,7 +175,10 @@ class GCodeArcOptimizerFilter(GCodeFilter):
                 extrusions['total']['path'] += path
                 extrusions['filament'][num] = extrusion
                 extrusions['path'][num] = path
-                extrusions['ratio'][num] = extrusions['filament'][num] / path
+                if num == (len(self.queue) - 1) and path < 0.00001:
+                    extrusions['ratio'][num] = -1
+                else:
+                    extrusions['ratio'][num] = extrusions['filament'][num] / path
             prev = line
         extrusions['avg']['filament'] = extrusions['total']['filament'] / len(self.queue)
         extrusions['avg']['path'] = extrusions['total']['path'] / len(self.queue)

--- a/gcodeutils/gcode_optimize_arcs.py
+++ b/gcodeutils/gcode_optimize_arcs.py
@@ -44,7 +44,7 @@ def main():
     GCodeArcOptimizerFilter().filter(gcode)
 
     # write back modified gcode
-    gcode.write(args.outfile if args.inplace is True else args.outfile)
+    gcode.write(open(args.infile.name, 'w') if args.inplace is True else args.outfile)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.3',
+    version='1.3.1',
 
     description='Reprap oriented gcode utilities',
     long_description=long_description,
@@ -111,7 +111,7 @@ setup(
             'gcode_tempcal=gcodeutils.gcode_tempcal:main',
             'gcode_mod=gcodeutils.gcode_mod:main',
             'gcode_stretch=gcodeutils.gcode_stretch:main',
-            'gcode_arc_optimize=gcodeutils.gcode_optimize_arcs:main',
+            'gcode_optimize_arc=gcodeutils.gcode_optimize_arcs:main',
         ],
     },
 


### PR DESCRIPTION
Sorry, but after installing via pip I encountered a bug wrt. to the --inplace option and a flaw in the naming of generated scripts
